### PR TITLE
APAAS-2751 Provide a mechanism to specify logging options to docker start

### DIFF
--- a/lib/em/docker/client/container.rb
+++ b/lib/em/docker/client/container.rb
@@ -221,6 +221,10 @@ module EventMachine
             end
           end
 
+          if opts[:log_opt]
+            req_hash["LogConfig"] = { "Type" => "json-file", "Config" => opts[:log_opt] }
+          end
+
           if opts[:bind_mounts]
             @bind_mounts = opts[:bind_mounts]
           end


### PR DESCRIPTION
The log-driver is still fixed to 'json-file` though, because that is what
apptail is expecting/able to handle.
